### PR TITLE
UX: ensure compatibility with drop-down sidebar

### DIFF
--- a/javascripts/discourse/templates/components/sidebar-theme-toggle.hbs
+++ b/javascripts/discourse/templates/components/sidebar-theme-toggle.hbs
@@ -7,6 +7,7 @@
       @value={{this.currentTheme}}
       @onChange={{action "setTheme"}}
       @class="sidebar-theme-toggle-dropdown"
+      @options={{hash placementStrategy="absolute"}}
     />
   </div>
 {{/if}}


### PR DESCRIPTION
The default `fixed` placement caused the dropdown to be hidden by overflow in the dropdown version of the sidebar... this fixes it by always positioning the dropdown absolutely (forces it above the toggle, instead of below) 


![Screenshot 2023-01-18 at 5 23 50 PM](https://user-images.githubusercontent.com/1681963/213308372-edb9684f-16b9-460e-90b1-fbb288ccdbb7.png)
