### PR TITLE
FIX: always ensure dropdown can scroll on mobile

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -105,3 +105,13 @@
     }
   }
 }
+
+// if the sidebar content isn't scrollable on mobile
+// the theme dropdown isn't scrollable either
+// this is a slight hack to always make it scrollable
+.mobile-view {
+  .hamburger-panel .menu-panel.slide-in .panel-body-contents {
+    min-height: calc(100% + 0.25em);
+    flex: 1;
+  }
+}


### PR DESCRIPTION
Issue discussed here: https://meta.discourse.org/t/sidebar-theme-toggle/242802/15?u=awesomerobot

When the sidebar sections are collapsed on mobile and the sidebar itself isn't scrollable, the theme dropdown will not scroll either. I've added a slight hack to ensure the theme dropdown is always scrollable, this seems to have no impact on the main scrollbar's scroll behavior. 