### PR TITLE
FIX: icon alignment causing sidebar scroll

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -45,7 +45,6 @@
     @if $hide-theme-name == "true" {
       left: 0.5em;
     }
-    bottom: -1px; // optical alignment
     z-index: z("dropdown") + 1;
     pointer-events: none;
   }


### PR DESCRIPTION
This was causing vertical scroll in the sidebar when the sidebar wouldn't normally scroll. 