### PR TITLE
FIX: wrong hover colour for switcher element in sidebar

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -29,7 +29,7 @@
       &:active,
       &:hover {
         outline: none;
-        background: var(--d-sidebar-highlight-color);
+        background: var(--d-sidebar-highlight-background);
       }
     }
   }


### PR DESCRIPTION
Currently I think it's using the wrong colour on hover:
<img width="319" alt="image" src="https://github.com/discourse/discourse-sidebar-theme-toggle/assets/101828855/159c8c91-cd69-4329-aa4c-6e5e9a2ade58">

Should probably be this?
<img width="255" alt="image" src="https://github.com/discourse/discourse-sidebar-theme-toggle/assets/101828855/6da3b4b7-e613-47f2-bdb4-eabe15fb6aa3">
