### PR TITLE
UX: fix placement issue that can break sidebar

### DIFF
--- a/javascripts/discourse/templates/components/sidebar-theme-toggle.hbs
+++ b/javascripts/discourse/templates/components/sidebar-theme-toggle.hbs
@@ -7,7 +7,7 @@
       @value={{this.currentTheme}}
       @onChange={{action "setTheme"}}
       class="sidebar-theme-toggle-dropdown"
-      @options={{hash placementStrategy="absolute"}}
+      @options={{hash placementStrategy="absolute" placement="top-start"}}
     />
   </div>
 {{/if}}


### PR DESCRIPTION
I believe this should fix the issue documented here: https://meta.discourse.org/t/after-clicking-on-a-topic-scroll-bar-the-sidebar-theme-toggle-breaks-the-sidebar-when-used/314263

sometimes when scrolling long topics, the menu would attempt to appear below the sidebar footer (which is already at the bottom of the page) and this would make the sidebar much taller than needed 

changing the placement to top should avoid this issue, as it will always appear above