### PR TITLE
UX: fix theme name overflow, update connector

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -73,7 +73,7 @@
   }
 
   &.select-kit.combo-box .select-kit-header {
-    padding-left: 3em;
+    padding-left: 2.5em;
 
     @if $hide-theme-name == "true" {
       padding: 1em;
@@ -84,8 +84,7 @@
     position: relative;
 
     .select-kit-header-wrapper {
-      margin-left: -0.5em;
-      width: calc(100% + 0.5em);
+      width: 100%;
     }
 
     .selected-name {
@@ -106,6 +105,7 @@
     }
 
     .name {
+      display: inline-block;
       min-width: 0;
 
       @include ellipsis;

--- a/javascripts/discourse/api-initializers/init-sidebar-theme-toggle.gjs
+++ b/javascripts/discourse/api-initializers/init-sidebar-theme-toggle.gjs
@@ -1,0 +1,6 @@
+import { apiInitializer } from "discourse/lib/api";
+import SidebarThemeToggle from "../components/sidebar-theme-toggle";
+
+export default apiInitializer((api) => {
+  api.renderInOutlet("sidebar-footer-actions", SidebarThemeToggle);
+});

--- a/javascripts/discourse/connectors/sidebar-footer-actions/sidebar-theme-toggle-connector.gjs
+++ b/javascripts/discourse/connectors/sidebar-footer-actions/sidebar-theme-toggle-connector.gjs
@@ -1,8 +1,0 @@
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
-import SidebarThemeToggle from "../../components/sidebar-theme-toggle";
-
-@tagName("")
-export default class SidebarThemeToggleConnector extends Component {
-  <template><SidebarThemeToggle /></template>
-}


### PR DESCRIPTION
Fixes the text overflow with long theme names, and moves the connector to an api-initializer 

Before:
<img width="590" height="106" alt="image" src="https://github.com/user-attachments/assets/4d24bdcb-e2bf-426b-9aab-dc59e6c3f954" />


After:
<img width="574" height="116" alt="image" src="https://github.com/user-attachments/assets/eec9c26f-549e-43d9-b823-e8bf79da5229" />
